### PR TITLE
[TCHL-41, TCHL-46] Improvements over the admin and user logout and minor enhancments

### DIFF
--- a/ChatSQL/code/cliAdmin.py
+++ b/ChatSQL/code/cliAdmin.py
@@ -24,12 +24,18 @@ def admin():
             deleteFile()
         elif choice == "3" or choice == "files":
             print(getFiles(database_path))
+#agg
         elif choice == "4" or choice == "exit":
-            print("Leaving admin section. You will be redirected to the main menu.")
-            break
+            confirmation = input("Are you sure you want to exit the admin section? (yes/no): ").lower()
+            if confirmation == "yes":
+                print("Leaving admin section. You will be redirected to the main menu.")
+                break
+            elif confirmation == "no":
+                print("Returning to the admin section menu.")
+            else:
+                print("Invalid choice. Returning to the admin section menu.")
         else:
             print("Invalid choice")
-
 
 def getFiles(database_path):
     files = os.listdir(database_path)
@@ -89,13 +95,35 @@ def addFile():
 def deleteFile():
     filename_to_delete = input("Enter the filename you want to delete from the database: ")
 
-    # Create the full path to the file in the database directory
-    file_path = os.path.join(database_path, filename_to_delete)
-
-    # Check if the file exists before attempting to delete
-    if os.path.exists(file_path):
-        # Delete the file
-        os.remove(file_path)
-        print(f"File '{filename_to_delete}' has been deleted.")
+    # Aggiunta dell'estensione .json se l'utente non l'ha fornita
+    if not filename_to_delete.endswith(".json"):
+        filename_to_delete_with_extension = filename_to_delete + ".json"
+        filename_to_delete_without_extension = filename_to_delete
     else:
+        filename_to_delete_with_extension = filename_to_delete
+        filename_to_delete_without_extension = filename_to_delete.replace(".json", "")
+
+    # Tentativo di eliminare il file specificato con e senza estensione .json
+    file_paths_to_try = [
+        os.path.join(database_path, filename_to_delete_with_extension),
+        os.path.join(database_path, filename_to_delete_without_extension)
+    ]
+
+    file_deleted = False
+    for file_path in file_paths_to_try:
+        if os.path.exists(file_path):
+            # Chiedi conferma prima di eliminare il file
+            confirm = input(f"Are you sure you want to delete '{os.path.basename(file_path)}'? (yes/no): ").lower()
+            if confirm == 'yes':
+                # Elimina il file
+                os.remove(file_path)
+                print(f"File '{os.path.basename(file_path)}' has been deleted.")
+                file_deleted = True
+                break
+            else:
+                print(f"Deletion of '{os.path.basename(file_path)}' canceled.")
+                file_deleted = True  # Consider the file as deleted to skip the "not file_deleted" message
+                break
+
+    if not file_deleted:
         print(f"File '{filename_to_delete}' does not exist in the database directory.")

--- a/ChatSQL/code/cliAdmin.py
+++ b/ChatSQL/code/cliAdmin.py
@@ -24,7 +24,6 @@ def admin():
             deleteFile()
         elif choice == "3" or choice == "files":
             print(getFiles(database_path))
-#agg
         elif choice == "4" or choice == "exit":
             confirmation = input("Are you sure you want to exit the admin section? (yes/no): ").lower()
             if confirmation == "yes":

--- a/ChatSQL/code/cliMain.py
+++ b/ChatSQL/code/cliMain.py
@@ -34,10 +34,15 @@ def main():
         elif choice == "2" or choice == "ask":
             pass
         elif choice == "3" or choice == "exit":
-            print("Exiting the program. Bye 👋🏻")
-            sys.exit()
-        else:
-            print("Invalid choice")
+            confirmation = input("Are you sure you want to exit the program? (yes/no): ").lower()
+            if confirmation == "yes":
+                print("Exiting the program. Bye 👋🏻")
+                sys.exit()
+            elif confirmation == "no":
+                print("Returning to the main menu.")
+            else:
+                print("Invalid choice. Returning to the main menu.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Before exiting the admin and users menu, now the user needs to confirm the operation.
Now, when a admin deletes a file, the `.json` extension can be omitted, and a confirmation is required to perform the action.